### PR TITLE
Improve plot dpi and 1-day width

### DIFF
--- a/server.py
+++ b/server.py
@@ -573,9 +573,13 @@ def _plot_segments(ax, ts, ys, segments, *args, **kwargs):
             kw["color"] = col
             ax.plot(ts[s:e+1], ys[s:e+1], *args, **kw)
 def _make_figure(seconds: int):
-    long_span = seconds >= 86_400  # ≥ 1 day
-    dpi = 500 if long_span else 150
-    fig, ax = plt.subplots(figsize=(12, 6), dpi=dpi)
+    """Return figure sized proportionally to the requested time span."""
+    days = seconds / 86_400
+    width = 12
+    if days >= 1:
+        width *= 1.5 if days < 1.5 else days
+    dpi = 500
+    fig, ax = plt.subplots(figsize=(width, 6), dpi=dpi)
 
     base = 9
     plt.rcParams.update({


### PR DESCRIPTION
## Summary
- always save plots with 500 dpi
- enlarge figure for a 1‑day range by 50%

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile server.py client.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68402f48e140832491bf379ebbee0024

## Обзор от Sourcery

Всегда сохранять все рисунки с разрешением 500 DPI и динамически регулировать ширину рисунка для лучшего соответствия временным диапазонам, применяя увеличение ширины в 1,5 раза для однодневных диапазонов и пропорциональное масштабирование для более длительных периодов.

Улучшения:
- Всегда устанавливать DPI графика на 500 независимо от длины диапазона
- Масштабировать ширину рисунка пропорционально запрошенному временному диапазону, с увеличением на 50% для однодневных диапазонов и расширенным масштабированием для более длительных периодов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Always save all figures at 500 DPI and dynamically adjust the figure width to better fit time spans, applying a 1.5× width for one-day ranges and proportional scaling for longer spans.

Enhancements:
- Always set plot DPI to 500 regardless of span length
- Scale figure width proportionally to the requested time span, with a 50% increase for one-day ranges and extended scaling for longer periods

</details>