### PR TITLE
Add alert removal command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ python client.py
 ```
 
 ### 4. Interact through Telegram
-* `/status` – current CPU/RAM/disk usage  
-* `CPU` / `RAM` buttons – historical charts  
+* `/status` – current CPU/RAM/disk usage
+* `CPU` / `RAM` buttons – historical charts
 * `Reboot` / `Shutdown` – remote control actions
+* `/setalert <key|name> <metric> <threshold>` – configure alerts
+* `/delalert <key|name> <metric>` – remove alert
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- document `/delalert` command
- expose `/delalert` in help and bot handlers
- implement `cmd_delalert` to remove alert settings

## Testing
- `python -m py_compile server.py client.py`

------

## Обзор от Sourcery

Позволяет пользователям настраивать и удалять оповещения о метриках для каждого ключа с помощью команд Telegram, сохранять эти настройки в JSON DB и автоматически уведомлять пользователей при превышении пороговых значений.

Новые возможности:
- Добавлена команда /delalert для удаления настроенных оповещений о метриках.
- Добавлена команда /setalert для настройки пороговых значений оповещений о метриках.
- Интегрирована логика отправки оповещений для отправки уведомлений Telegram при превышении метриками пороговых значений.

Улучшения:
- Зарегистрированы обработчики setalert и delalert при запуске бота и добавлены в справочное сообщение.
- Расширена схема JSON DB для сохранения конфигураций оповещений и отслеживания временных меток последних уведомлений.

Документация:
- Обновлены README и текст справки в боте с информацией об использовании /setalert и /delalert.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable users to configure and remove per-key metric alerts via Telegram commands, persist these settings in the JSON DB, and automatically notify users when thresholds are exceeded

New Features:
- Add /delalert command for users to delete configured metric alerts
- Add /setalert command for users to configure metric alert thresholds
- Integrate alert dispatch logic to send Telegram notifications when metrics breach thresholds

Enhancements:
- Register setalert and delalert handlers in the bot startup and expose both in the help message
- Extend JSON DB schema to persist alert configurations and track last notification timestamps

Documentation:
- Update README and in-bot help text with /setalert and /delalert usage

</details>