### PR TITLE
Improve GPU metrics collection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ GPUtil>=1.4.0
 speedtest-cli>=2.1
 pynvml~=12.0.0
 numpy~=2.2.6
+wmi; platform_system=="Windows"
+pywin32>=306; platform_system=="Windows"


### PR DESCRIPTION
## Summary
- detect GPU vendor to avoid incorrect libraries
- split AMD/NVIDIA collection logic and add a WMI fallback for AMD cards on Windows
- list optional Windows-only packages

## Testing
- `python -m py_compile client.py server.py`

------

## Обзор от Sourcery

Улучшена коллекция метрик GPU путем внедрения определения производителя, разделения логики NVIDIA и AMD, добавления резервного варианта WMI для Windows для карт AMD и обновления зависимостей, специфичных для Windows.

Новые возможности:
- Добавлена функция определения производителя GPU для идентификации устройств NVIDIA или AMD на разных платформах.
- Разделен сбор метрик GPU на отдельные функции сбора для NVIDIA и AMD.
- Реализован резервный вариант на основе WMI для метрик AMD GPU в Windows.

Исправления ошибок:
- Предотвращено некорректное использование библиотеки GPU путем выбора коллекторов с помощью определения производителя.

Улучшения:
- Предпринята попытка использования всех коллекторов метрик GPU, когда определение производителя является неубедительным.
- Уточнен `gather_gpu_metrics` для маршрутизации вызовов на основе обнаруженного производителя.

Сборка:
- Указаны `wmi` и `pywin32` в качестве необязательных зависимостей только для Windows в `requirements.txt`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve GPU metrics collection by introducing vendor detection, separating NVIDIA and AMD logic, adding a Windows WMI fallback for AMD cards, and updating Windows-specific dependencies.

New Features:
- Add GPU vendor detection function to identify NVIDIA or AMD devices across platforms
- Split GPU metrics gathering into dedicated NVIDIA and AMD collection functions
- Implement WMI-based fallback for AMD GPU metrics on Windows

Bug Fixes:
- Prevent incorrect GPU library usage by selecting collectors via vendor detection

Enhancements:
- Attempt all GPU metric collectors when vendor detection is inconclusive
- Refine gather_gpu_metrics to route calls based on detected vendor

Build:
- List wmi and pywin32 as optional Windows-only dependencies in requirements.txt

</details>