### PR TITLE
Fix wmic console popup on Windows

### DIFF
--- a/client.py
+++ b/client.py
@@ -395,10 +395,14 @@ def detect_gpu_vendor() -> str | None:
             except Exception:
                 pass
         try:
+            kwargs = {}
+            if hasattr(subprocess, "CREATE_NO_WINDOW"):
+                kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
             out = subprocess.check_output(
                 ["wmic", "path", "Win32_VideoController", "get", "Name"],
                 text=True,
                 timeout=2,
+                **kwargs,
             ).lower()
             if "nvidia" in out:
                 return "nvidia"


### PR DESCRIPTION
## Summary
- avoid opening a window when invoking `wmic` for GPU detection

## Testing
- `python -m py_compile client.py`

------
https://chatgpt.com/codex/tasks/task_e_684053272f208324ab15cf07d31bd258