### PR TITLE
Add network throughput metrics

### DIFF
--- a/server.py
+++ b/server.py
@@ -211,7 +211,7 @@ def record_metric(secret: str, data: Dict[str, Any]):
                ram_used, ram_total, swap, swap_used, swap_total,
                vram_used, vram_total, cpu_temp, gpu_temp,
                net_up, net_down, uptime, disks
-           ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+           ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
         (
             secret,
             int(time.time()),

--- a/server.py
+++ b/server.py
@@ -342,9 +342,10 @@ def format_status(row: sqlite3.Row) -> str:
         f"🧠 SWAP: {human_bytes(row['swap_used'])} / {human_bytes(row['swap_total'])} ({row['swap']:.1f}%)",
     ]
     if row['net_up'] is not None and row['net_down'] is not None:
-        lines.append(
-            f"📡 Net: ↑ {human_bytes(row['net_up'])}/s ↓ {human_bytes(row['net_down'])}/s"
-        )
+        lines.extend([
+            "*━━━━━━━━━━━NET━━━━━━━━━━━*",
+            f"📡 Net: ↑ {human_bytes(row['net_up'])}/s ↓ {human_bytes(row['net_down'])}/s",
+        ])
     if row['gpu'] is not None:
         lines.extend([
             "*━━━━━━━━━━━GPU━━━━━━━━━━━*",


### PR DESCRIPTION
## Summary
- capture per-interval network usage in client
- store `net_up`/`net_down` in SQLite and PushPayload
- show current network activity in status output
- support plotting these metrics

## Testing
- `python -m py_compile client.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_684054e62d5483248f34d110874f9e75

## Краткое описание от Sourcery

Добавлена сквозная поддержка метрик пропускной способности сети для каждого интервала, от сбора на стороне клиента до хранения на сервере, отображения статуса и построения графиков.

Новые возможности:
- Сбор данных о пропускной способности сети (загрузка и скачивание) для каждого интервала на стороне клиента.
- Сохранение значений `net_up` и `net_down` в базе данных метрик и модели `PushPayload`.
- Отображение текущей скорости загрузки/скачивания сети в выходных данных статуса.
- Поддержка построения графиков метрик пропускной способности сети наряду с существующими графиками ресурсов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add end-to-end support for per-interval network throughput metrics, from client collection through server storage, status display, and plotting

New Features:
- Collect per-interval network upload and download throughput in the client
- Persist net_up and net_down values in the metrics database and PushPayload model
- Show current network upload/download speeds in the status output
- Support plotting of network throughput metrics alongside existing resource charts

</details>