### PR TITLE
Fix fingerprint saving on TLS pinning

### DIFF
--- a/client.py
+++ b/client.py
@@ -675,11 +675,10 @@ def _save_fp(fp: str) -> None:
 
 def _fetch_cert_der(parsed) -> bytes:
     host, port = parsed.hostname, parsed.port or 443
-    ctx = ssl.create_default_context()
-    with ctx.wrap_socket(socket.socket(), server_hostname=host) as s:
-        s.settimeout(5)
-        s.connect((host, port))
-        return s.getpeercert(binary_form=True)
+    ctx = ssl._create_unverified_context()
+    with socket.create_connection((host, port), timeout=5) as sock:
+        with ctx.wrap_socket(sock, server_hostname=host) as s:
+            return s.getpeercert(binary_form=True)
 
 def _mismatch_exit(pinned: str, new_fp: str) -> None:
     msg = (


### PR DESCRIPTION
## Summary
- handle self-signed certs when fetching TLS fingerprint

## Testing
- `python -m py_compile client.py server.py db.py graphs.py`
- `pytest -q`

------

## Обзор от Sourcery

Исправлено сохранение отпечатков пальцев при TLS-пиннинге за счет использования непроверенного SSL-контекста для поддержки самоподписанных сертификатов и упрощения логики подключения сокета.

Исправления ошибок:
- Разрешено получение TLS-сертификата DER для самоподписанных сертификатов путем переключения на непроверенный SSL-контекст.
- Заменена ручная настройка сокета на `socket.create_connection` и обернута для упрощения подключения и обработки тайм-аутов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix fingerprint saving on TLS pinning by using an unverified SSL context to support self-signed certificates and simplifying the socket connection logic.

Bug Fixes:
- Allow fetching TLS certificate DER for self-signed certificates by switching to an unverified SSL context.
- Replace manual socket setup with socket.create_connection and wrap it to streamline the connection and timeout handling.

</details>