### PR TITLE
Fix first /status output

### DIFF
--- a/client.py
+++ b/client.py
@@ -819,6 +819,8 @@ def do_shutdown():
 
 log.info("Agent started → %s", SERVER)
 psutil.cpu_percent(interval=None)
+# инициализируем кэш процессов, чтобы первые /status не показывали 0%
+gather_top_processes()
 
 while True:
     metrics = gather_metrics()


### PR DESCRIPTION
## Summary
- warm up process cache on startup so the first `/status` shows correct CPU load

## Testing
- `python -m py_compile client.py server.py db.py graphs.py`

------

## Обзор от Sourcery

Прогреть кэш процессов при запуске агента, чтобы первая команда `/status` сообщала правильную загрузку ЦП, а не 0%.

Улучшения:
- Инициализировать измерение процента загрузки ЦП при запуске с помощью `psutil.cpu_percent(interval=None)`.
- Предварительно загрузить метрики топовых процессов при запуске, вызвав `gather_top_processes()`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Warm up process cache on agent startup to ensure the first `/status` command reports the correct CPU load instead of 0%.

Enhancements:
- Initialize CPU percent measurement on startup via `psutil.cpu_percent(interval=None)`.
- Preload top process metrics at startup by calling `gather_top_processes()`.

</details>