### PR TITLE
Fix Markdown formatting

### DIFF
--- a/server.py
+++ b/server.py
@@ -9,6 +9,7 @@ import re
 import secrets
 from html import escape
 from telegram.constants import ParseMode
+from telegram.helpers import escape_markdown
 import time
 import sqlite3
 import string
@@ -344,7 +345,7 @@ def format_status(row: Mapping[str, Any]) -> str:
             name_raw = p.get('name', '')
             if name_raw and name_raw.lower() == 'system idle process':
                 continue
-            name = escape(name_raw[:20])
+            name = escape_markdown(name_raw[:20], version=1)
             lines.append(
                 f"⚙️ {name}: 🖥️ {p['cpu']:.1f}% 🧠 {human_bytes(p['ram'])}"
             )
@@ -369,8 +370,9 @@ def format_status(row: Mapping[str, Any]) -> str:
     if disks:
         lines.append("*━━━━━━━━━━━DISKS━━━━━━━━━━*")
         for d in disks:
+            mount = escape_markdown(d['mount'], version=1)
             line = (
-                f"💾 {d['mount']}: {disk_bar(d['percent'])} "
+                f"💾 {mount}: {disk_bar(d['percent'])} "
                 f"{d['percent']:.0f}% ({human_bytes(d['used'])} / {human_bytes(d['total'])})"
             )
             if d['percent'] >= 90:


### PR DESCRIPTION
## Summary
- escape mount points and process names properly when formatting status messages

## Testing
- `python -m py_compile server.py`
- `python -m py_compile client.py`


------
https://chatgpt.com/codex/tasks/task_e_6844b53286908324ba52e53a2bba3902

## Обзор от Sourcery

Исправление экранирования Markdown в форматировании статусных сообщений для предотвращения непреднамеренного форматирования

Исправления ошибок:
- Использовать `escape_markdown` для названий процессов, чтобы правильно экранировать специальные символы.
- Применить `escape_markdown` к точкам монтирования дисков, чтобы избежать проблем с форматированием Markdown.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix markdown escaping in status message formatting to prevent unintended formatting

Bug Fixes:
- Use escape_markdown for process names to properly escape special characters
- Apply escape_markdown to disk mount points to avoid markdown formatting issues

</details>