### PR TITLE
Show partial status on key button

### DIFF
--- a/server.py
+++ b/server.py
@@ -782,6 +782,30 @@ async def cb_action(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         if not entry or not is_owner(entry, q.from_user.id):
             return await q.edit_message_text("🚫 Нет доступа.")
 
+        row = sql.execute(
+            "SELECT * FROM metrics WHERE secret=? ORDER BY ts DESC LIMIT 1",
+            (secret,),
+        ).fetchone()
+
+        orig = q.message.text or ""
+        prefixes = ("💻", "⏳", "Нет данных", "⚠️")
+        from_status = any(orig.startswith(p) for p in prefixes)
+
+        if from_status:
+            await q.edit_message_text(
+                text=f"⏳ Обновляем...\n{orig}",
+                parse_mode="Markdown",
+                reply_markup=q.message.reply_markup,
+            )
+        else:
+            if row:
+                await q.edit_message_text(
+                    format_status(row),
+                    parse_mode="Markdown",
+                    reply_markup=status_keyboard(secret),
+                )
+            else:
+                await q.edit_message_text("Нет данных от агента.")
 
         entry.setdefault("pending", []).append("status")
         save_db(db)
@@ -795,16 +819,6 @@ async def cb_action(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
                 "msg_id": q.message.message_id,
             },
         )
-
-        # добавляем индикатор обновления, если ещё не добавлен
-        orig = q.message.text or ""
-        prefixes = ("⏳ ", "⌛ ", "⏳️")
-        if not any(orig.startswith(p) for p in prefixes):
-            await q.edit_message_text(
-                text=f"⏳ Обновляем...\n{orig}",
-                parse_mode="Markdown",
-                reply_markup=q.message.reply_markup,
-            )
         return
     if action in {"reboot", "shutdown"}:
         secret = parts[1]


### PR DESCRIPTION
## Summary
- display cached metrics when clicking a key button in /list
- keep requesting full status in background
- show the updating indicator only when refreshing from an existing status

## Testing
- `python -m py_compile server.py client.py db.py graphs.py`
- `pip install -q -r requirements.txt`


------

## Обзор от Sourcery

Отображение кэшированных метрик сразу после нажатия на кнопку и уточнение логики индикатора обновления, чтобы он появлялся только при обновлении существующего статуса, в то время как полный статус получается в фоновом режиме.

Улучшения:
- Отображение кэшированных метрик мгновенно, если они доступны, при нажатии на кнопку статуса
- Запрос полного статуса в фоновом режиме без блокировки UI
- Отображение индикатора "обновления" только при обновлении уже отображаемого статуса
- Удаление избыточного пути кода индикатора обновления

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Display cached metrics immediately on key button click and refine the updating indicator logic to only appear when refreshing an existing status while full status is fetched in the background.

Enhancements:
- Show cached metrics instantly if available when the status button is clicked
- Request full status in the background without blocking the UI
- Only display the "updating" indicator when refreshing an already shown status
- Remove redundant update-indicator code path

</details>