### PR TITLE
Fix update message formatting

### DIFF
--- a/server.py
+++ b/server.py
@@ -794,7 +794,6 @@ async def cb_action(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         if from_status:
             await q.edit_message_text(
                 text=f"⏳ Обновляем...\n{orig}",
-                parse_mode="Markdown",
                 reply_markup=q.message.reply_markup,
             )
         else:


### PR DESCRIPTION
## Summary
- avoid using Markdown when temporarily showing previous status

## Testing
- `python -m py_compile server.py client.py db.py graphs.py`

------
https://chatgpt.com/codex/tasks/task_e_6845782b3e3083248aae8a3742402c39