### PR TITLE
Fix CPU usage calculation for top processes

### DIFF
--- a/client.py
+++ b/client.py
@@ -27,6 +27,7 @@ import locale
 import psutil
 # Кэш для вычисления CPU без задержки
 PROC_CACHE: dict[int, tuple[float, float]] = {}
+CPU_CORES = psutil.cpu_count(logical=False) or psutil.cpu_count() or 1
 import requests
 from requests import Session
 from requests.exceptions import SSLError, ConnectionError
@@ -183,7 +184,7 @@ def gather_top_processes(count: int = 5) -> List[dict]:
             PROC_CACHE[p.pid] = (cpu_time, now)
 
             mem = p.memory_info().rss
-            cpu /= psutil.cpu_count() or 1
+            cpu /= CPU_CORES
 
             key = name_raw.lower()
             agg = aggregated.setdefault(key, {"name": name_raw, "cpu": 0.0, "ram": 0, "count": 0})


### PR DESCRIPTION
## Summary
- determine physical CPU core count once during startup
- use physical cores when normalizing per-process CPU load

## Testing
- `python -m py_compile client.py server.py db.py graphs.py`

------
## Summary by Sourcery

Нормализация использования CPU для каждого процесса с использованием заранее вычисленного количества физических ядер для корректировки расчета загрузки CPU для топовых процессов.

Исправления ошибок:
- Исправлен расчет использования CPU путем нормализации загрузки CPU для каждого процесса с правильным количеством физических ядер CPU.

Улучшения:
- Вычисление количества физических ядер CPU один раз при запуске, чтобы избежать повторных системных вызовов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize per-process CPU usage using a precomputed physical core count to correct the CPU load calculation for top processes.

Bug Fixes:
- Fix CPU usage calculation by normalizing per-process CPU load with the correct physical CPU core count.

Enhancements:
- Compute the physical CPU core count once at startup to avoid repeated system calls.

</details>