### PR TITLE
Async plotting

### DIFF
--- a/server.py
+++ b/server.py
@@ -156,6 +156,10 @@ def best_unit(max_val_bytes: float) -> tuple[float, str]:
 def disk_bar(p: float, length: int = 10) -> str:
     filled = int(round(p * length / 100))
     return "█" * filled + "░" * (length - filled)
+
+async def run_plot(func, *args):
+    """Run plotting function in a thread."""
+    return await asyncio.to_thread(func, *args)
 async def check_speedtest_done(ctx: ContextTypes.DEFAULT_TYPE):
     job  = ctx.job
     data = job.data
@@ -969,13 +973,13 @@ async def cb_action(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         secret = parts[3]
 
         if metric == "all":
-            buf = plot_all_metrics(secret, seconds)
+            buf = await run_plot(plot_all_metrics, secret, seconds)
             caption = f"Все метрики за {timedelta(seconds=seconds)}"
         elif metric == "net":
-            buf = plot_net(secret, seconds)
+            buf = await run_plot(plot_net, secret, seconds)
             caption = f"NET за {timedelta(seconds=seconds)}"
         else:
-            buf = plot_metric(secret, metric, seconds)
+            buf = await run_plot(plot_metric, secret, metric, seconds)
             caption = f"{metric.upper()} за {timedelta(seconds=seconds)}"
 
         if not buf:


### PR DESCRIPTION
## Summary
- run plotting functions in separate threads via `asyncio.to_thread`
- integrate new async wrapper into callback handler

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------

## Краткое описание от Sourcery

Перенос блокирующих операций построения графиков в фоновые потоки путем внедрения асинхронной обертки и обновления обработчиков обратного вызова для ожидания неблокирующего выполнения графиков

Улучшения:
- Добавлен вспомогательный метод `run_plot`, который выполняет функции построения графиков в отдельном потоке через `asyncio.to_thread`
- Заменены синхронные вызовы `plot_all_metrics`, `plot_net` и `plot_metric` в `cb_action` на ожидаемые вызовы `run_plot`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Offload blocking plotting operations to background threads by introducing an async wrapper and updating callback handlers to await non-blocking plot execution

Enhancements:
- Add run_plot helper that executes plotting functions in a separate thread via asyncio.to_thread
- Replace synchronous plot_all_metrics, plot_net, and plot_metric calls in cb_action with awaited run_plot invocations

</details>