### PR TITLE
Implement WebSocket agent channel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pynvml~=12.0.0
 numpy~=2.2.6
 wmi; platform_system=="Windows"
 pywin32>=306; platform_system=="Windows"
+websockets>=12.0


### PR DESCRIPTION
## Summary
- enable WebSocket support in FastAPI server
- switch agent to persistent WebSocket connection
- queue commands via WebSocket instead of polling
- add `websockets` dependency

## Testing
- `python -m py_compile server.py client.py`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6846d1c1fabc832486e83eace39d088f

## Обзор от Sourcery

Реализация постоянного WebSocket-соединения между агентом и сервером FastAPI для замены опроса (polling), что обеспечивает передачу метрик и обработку команд в реальном времени.

Новые возможности:
- Добавление WebSocket-endpoint на сервере для подключения агентов.
- Переключение клиентского агента на использование постоянного WebSocket-соединения для отправки метрик и получения команд.
- Внедрение поддержки WebSocket и закрепления сертификатов (certificate pinning) в клиенте.

Улучшения:
- Замена цикла опроса асинхронным WebSocket-циклом в клиенте.
- Удаление периодической HTTP pull/push механики в пользу обмена сообщениями, управляемого событиями.

Сборка:
- Добавление зависимости "websockets" в requirements.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement persistent WebSocket communication between the agent and the FastAPI server to replace polling, enabling real-time metric pushing and command handling.

New Features:
- Add a WebSocket endpoint on the server for agent connections.
- Switch the client agent to use a persistent WebSocket connection for sending metrics and receiving commands.
- Introduce WebSocket support and certificate pinning in the client.

Enhancements:
- Replace the polling loop with an asynchronous WebSocket loop in the client.
- Remove periodic HTTP pull/push mechanics in favor of event-driven messaging.

Build:
- Add the "websockets" dependency to requirements.

</details>