### PR TITLE
Add reconnection loop for WebSocket client

### DIFF
--- a/client/__main__.py
+++ b/client/__main__.py
@@ -793,16 +793,23 @@ async def ws_main() -> None:
         else:
             ssl_ctx = ssl._create_unverified_context()
     _ensure_fp(SERVER)
-    async with websockets.connect(uri, ssl=ssl_ctx) as ws:
-        log.info("Agent WS connected → %s", uri)
-        WS_LOOP = asyncio.get_running_loop()
-        WS_CONN = ws
-        sender = asyncio.create_task(_send_metrics_loop(ws))
-        receiver = asyncio.create_task(_recv_loop(ws))
-        done, pending = await asyncio.wait([sender, receiver], return_when=asyncio.FIRST_EXCEPTION)
-        for t in pending:
-            t.cancel()
-        await asyncio.gather(*pending, return_exceptions=True)
+    while True:
+        try:
+            async with websockets.connect(uri, ssl=ssl_ctx) as ws:
+                log.info("Agent WS connected → %s", uri)
+                WS_LOOP = asyncio.get_running_loop()
+                WS_CONN = ws
+                sender = asyncio.create_task(_send_metrics_loop(ws))
+                receiver = asyncio.create_task(_recv_loop(ws))
+                done, pending = await asyncio.wait(
+                    [sender, receiver], return_when=asyncio.FIRST_EXCEPTION
+                )
+                for t in pending:
+                    t.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
+        except Exception as exc:
+            log.error("WS connection error: %s", exc)
+            await asyncio.sleep(5)
 
 # ────────────────────────── main loop ─────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- keep trying to connect the client via WebSocket in a loop
- wait a few seconds on failure before reconnecting

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847393aa05483248d36fbde7aad42f2

## Обзор от Sourcery

Реализована автоматическая переподключение для WebSocket-клиента путем зацикливания логики подключения с обработкой ошибок и фиксированной задержкой повторных попыток.

Новые возможности:
- Обернуть WebSocket-соединение в цикл переподключения для поддержания связи

Улучшения:
- Регистрировать ошибки подключения и делать паузу перед повторной попыткой

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement automatic reconnection for the WebSocket client by looping the connection logic with error handling and a fixed retry delay.

New Features:
- Wrap WebSocket connection in a reconnection loop to maintain connectivity

Enhancements:
- Log connection errors and pause before retrying

</details>