### PR TITLE
Fix Windows packaging issue with speedtest

### DIFF
--- a/client/__main__.py
+++ b/client/__main__.py
@@ -806,4 +806,11 @@ async def ws_main() -> None:
 
 # ────────────────────────── main loop ─────────────────────────────────────
 
-asyncio.run(ws_main())
+def main() -> None:
+    asyncio.run(ws_main())
+
+
+if __name__ == "__main__":
+    import multiprocessing as _mp
+    _mp.freeze_support()
+    main()


### PR DESCRIPTION
## Summary
- guard main entry in `client/__main__.py`
- call `multiprocessing.freeze_support()` to allow process pool when frozen

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile client/__main__.py client/worker.py server/*.py`


------

## Краткое описание от Sourcery

Включена совместимая с Windows упаковка для speedtest клиента путем защиты основной точки входа и вызова multiprocessing.freeze_support().

Исправления ошибок:
- Защищена основная точка входа клиента под `__main__`, чтобы предотвратить непреднамеренное выполнение.
- Вызван `multiprocessing.freeze_support()`, чтобы разрешить пулы процессов, когда приложение заморожено в Windows.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable Windows-compatible packaging for the speedtest client by guarding the main entry point and invoking multiprocessing.freeze_support().

Bug Fixes:
- Guard the client’s main entry point under __main__ to prevent unintended execution.
- Invoke multiprocessing.freeze_support() to allow process pools when the application is frozen on Windows.

</details>