### PR TITLE
Auto reconnect WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ python -m client
 | `AGENT_SERVER_IP` | client | prompt | Server IPv4 address |
 | `AGENT_PORT` | client | 8000 | Server port |
 | `AGENT_INTERVAL` | client | 5 | Seconds between metric pushes |
+| `AGENT_RECONNECT_DELAY` | client | 5 | Seconds before reconnecting |
 | `AGENT_VERIFY_SSL` | client | 1 | `0` = disable verification |
 
 Values are persisted to a local `.env` file after the first run.


### PR DESCRIPTION
## Summary
- reconnect WebSocket client when connection drops
- expose AGENT_RECONNECT_DELAY option
- document the reconnect delay env var

## Testing
- `python -m py_compile client/__main__.py server/__main__.py client/worker.py server/db.py server/graphs.py`


------

## Обзор от Sourcery

Включено автоматическое переподключение WebSocket-клиента с настраиваемой задержкой.

Новые возможности:
- Автоматическое переподключение WebSocket-клиента при обрыве соединения
- Добавлена переменная окружения `AGENT_RECONNECT_DELAY` для настройки задержки переподключения

Улучшения:
- Логирование задержки переподключения в выводе конфигурации клиента

Документация:
- Документирована опция `AGENT_RECONNECT_DELAY` в README

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable automatic reconnection of the WebSocket client with a configurable delay.

New Features:
- Automatically reconnect the WebSocket client when the connection drops
- Expose `AGENT_RECONNECT_DELAY` environment variable to configure the reconnect delay

Enhancements:
- Log the reconnect delay in the client configuration output

Documentation:
- Document the `AGENT_RECONNECT_DELAY` option in the README

</details>