### PR TITLE
Add worker executor shutdown on client exit

### DIFF
--- a/client/__main__.py
+++ b/client/__main__.py
@@ -23,7 +23,9 @@ import shutil
 import subprocess
 
 import psutil
-from client.worker import run_speedtest, run_diagnostics, submit
+from client.worker import run_speedtest, run_diagnostics, submit, shutdown_executor
+
+atexit.register(shutdown_executor)
 # Кэш для вычисления CPU без задержки
 PROC_CACHE: dict[int, tuple[float, float]] = {}
 GPU_VENDOR: str | None = None

--- a/client/worker.py
+++ b/client/worker.py
@@ -12,6 +12,7 @@ import locale
 
 __all__ = [
     "submit",
+    "shutdown_executor",
     "run_speedtest",
     "run_diagnostics",
 ]
@@ -21,6 +22,11 @@ _executor = ProcessPoolExecutor()
 def submit(func, *args, **kwargs) -> Future:
     """Отправить функцию в пул процессов."""
     return _executor.submit(func, *args, **kwargs)
+
+
+def shutdown_executor() -> None:
+    """Корректно завершить пул процессов."""
+    _executor.shutdown(wait=False)
 
 
 def _subprocess_flags() -> int:


### PR DESCRIPTION
## Summary
- add `shutdown_executor()` helper in `client/worker.py`
- register executor shutdown via `atexit` in `client/__main__.py`

## Testing
- `python -m py_compile client/worker.py client/__main__.py`


------

## Краткое описание от Sourcery

Обеспечение корректного завершения пула рабочих процессов при выходе клиентского приложения

Улучшения:
- Внедрение вспомогательной функции `shutdown_executor()` в модуль worker для завершения пула executor без ожидания
- Регистрация `shutdown_executor()` с помощью `atexit` в точке входа клиента для запуска при выходе из процесса

Тесты:
- Добавление проверки компиляции для модулей worker и main для проверки синтаксиса

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the worker process pool is cleanly shut down when the client application exits

Enhancements:
- Introduce shutdown_executor() helper in worker module to terminate the executor pool without waiting
- Register shutdown_executor() with atexit in the client entrypoint to trigger on process exit

Tests:
- Add compilation check for worker and main modules to verify syntax

</details>