### PR TITLE
Limit graph workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ python -m client
 |----------|-----------|---------|---------|
 | `BOT_TOKEN` | server | — | Telegram bot token (required) |
 | `PORT` | server | 8000 | WebSocket listening port |
+| `GRAPH_WORKERS` | server | 1 | Processes for each chart (terminated after use) |
 | `AGENT_SECRET` | client | — | Secret linking agent to server |
 | `AGENT_SERVER_IP` | client | prompt | Server IPv4 address |
 | `AGENT_PORT` | client | 8000 | Server port |


### PR DESCRIPTION
## Summary
- reduce workers in `server/graphs` to avoid spawning many heavy processes
- document new `GRAPH_WORKERS` environment variable
- terminate per-request graph workers after use

## Testing
- `python -m py_compile server/graphs.py`


------

## Обзор от Sourcery

Ограничить количество процессов, используемых для рендеринга графиков, путем создания экземпляра ProcessPoolExecutor для каждого запроса с размером, контролируемым переменной среды GRAPH_WORKERS, и завершения его работы после каждой задачи.

Новые возможности:
- Введена переменная среды GRAPH_WORKERS для настройки количества рабочих процессов для графиков.

Улучшения:
- Создается новый ProcessPoolExecutor для каждой задачи построения графика и обеспечивается минимум один рабочий процесс.
- Автоматическое завершение работы исполнителя после каждой задачи для освобождения памяти.

Документация:
- Документирована настройка GRAPH_WORKERS в README с указанием значения по умолчанию и назначения.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Limit the number of processes used for chart rendering by instantiating a ProcessPoolExecutor per request with size controlled by the GRAPH_WORKERS environment variable and shutting it down after each task

New Features:
- Introduce GRAPH_WORKERS environment variable to configure the number of graph worker processes

Enhancements:
- Create a fresh ProcessPoolExecutor for each graph task and enforce a minimum of one worker process
- Automatically terminate the executor after each task to free memory

Documentation:
- Document the GRAPH_WORKERS setting in the README with its default value and purpose

</details>