### PR TITLE
Add console toggle via tray icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ python -m client
 | `AGENT_INTERVAL` | client | 5 | Seconds between metric pushes |
 | `AGENT_RECONNECT_DELAY` | client | 5 | Seconds before reconnecting |
 | `AGENT_VERIFY_SSL` | client | 1 | `0` = disable verification |
+| `AGENT_ICON_FILE` | client |  | Tray icon image path |
 
 Values are persisted to a local `.env` file after the first run.
 
@@ -99,6 +100,16 @@ fingerprint to `~/.bot_fingerprint.json`. If the certificate later changes
 (e.g. the server was reinstalled), the agent will stop with a dialog
 window advising you to delete this file and restart. This prevents silently
 accepting unexpected certificates.
+
+### Tray icon
+When the client starts, an icon appears in the system tray. Right-click this icon to exit the program. To use your own image, set `AGENT_ICON_FILE` to the path of a PNG before launching:
+```bash
+export AGENT_ICON_FILE="/path/my_icon.png"
+python -m client
+```
+On Windows double clicking the icon toggles the console window. If the program
+was built using `--noconsole`, the console will be allocated when you double
+click.
 
 ## Project Structure
 ```

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ python -m client
 | `AGENT_INTERVAL` | client | 5 | Seconds between metric pushes |
 | `AGENT_RECONNECT_DELAY` | client | 5 | Seconds before reconnecting |
 | `AGENT_VERIFY_SSL` | client | 1 | `0` = disable verification |
-| `AGENT_ICON_FILE` | client |  | Tray icon image path |
+| `AGENT_ICON_FILE` | client | `client/icon.png` if exists | Tray icon image path |
 
 Values are persisted to a local `.env` file after the first run.
 
@@ -107,6 +107,7 @@ When the client starts, an icon appears in the system tray. Right-click this ico
 export AGENT_ICON_FILE="/path/my_icon.png"
 python -m client
 ```
+If this variable is not set, the client will try to load `client/icon.png` from the program directory.
 On Windows double clicking the icon toggles the console window. If the program
 was built using `--noconsole`, the console will be allocated when you double
 click.

--- a/client/__main__.py
+++ b/client/__main__.py
@@ -176,6 +176,10 @@ INTERVAL = int(os.getenv("AGENT_INTERVAL", "5"))
 RECONNECT_DELAY = int(os.getenv("AGENT_RECONNECT_DELAY", "5"))
 
 ICON_FILE = os.getenv("AGENT_ICON_FILE")
+if not ICON_FILE:
+    candidate = Path(__file__).with_name("icon.png")
+    if candidate.exists():
+        ICON_FILE = str(candidate)
 if ICON_FILE and not Path(ICON_FILE).exists():
     log.warning("Tray icon not found: %s", ICON_FILE)
     ICON_FILE = None

--- a/client/__main__.py
+++ b/client/__main__.py
@@ -23,9 +23,12 @@ import shutil
 import subprocess
 
 import psutil
+from PIL import Image
+import pystray
 from client.worker import run_speedtest, run_diagnostics, submit, shutdown_executor
 
 atexit.register(shutdown_executor)
+atexit.register(lambda: TRAY_ICON and TRAY_ICON.stop())
 # Кэш для вычисления CPU без задержки
 PROC_CACHE: dict[int, tuple[float, float]] = {}
 GPU_VENDOR: str | None = None
@@ -36,10 +39,57 @@ CPU_CORES = psutil.cpu_count(logical=False) or psutil.cpu_count() or 1
 import websockets
 WS_LOOP: asyncio.AbstractEventLoop | None = None
 WS_CONN: websockets.WebSocketClientProtocol | None = None
+TRAY_ICON: pystray.Icon | None = None
 try:
     import pynvml
 except Exception:
     pynvml = None
+
+if os.name == "nt":
+    import ctypes
+
+    kernel32 = ctypes.windll.kernel32
+    user32 = ctypes.windll.user32
+
+    SW_HIDE = 0
+    SW_RESTORE = 9
+
+    def _console_hwnd() -> int:
+        return kernel32.GetConsoleWindow()
+
+    def toggle_console() -> None:
+        hwnd = _console_hwnd()
+        if not hwnd:
+            if kernel32.AllocConsole():
+                sys.stdout = open("CONOUT$", "w", buffering=1)
+                sys.stderr = open("CONOUT$", "w", buffering=1)
+                sys.stdin = open("CONIN$", "r")
+                hwnd = _console_hwnd()
+        if hwnd:
+            if user32.IsWindowVisible(hwnd):
+                user32.ShowWindow(hwnd, SW_HIDE)
+            else:
+                user32.ShowWindow(hwnd, SW_RESTORE)
+                user32.SetForegroundWindow(hwnd)
+
+    def _hide_console_on_minimize() -> None:
+        hwnd = _console_hwnd()
+        if not hwnd:
+            return
+        visible = True
+        while True:
+            time.sleep(0.5)
+            if visible and user32.IsIconic(hwnd):
+                user32.ShowWindow(hwnd, SW_HIDE)
+                visible = False
+            elif not visible and user32.IsWindowVisible(hwnd):
+                visible = True
+            if not user32.IsWindow(hwnd):
+                break
+else:
+    def toggle_console() -> None:
+        pass
+
 
 log = logging.getLogger("pc-agent")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
@@ -124,6 +174,43 @@ SCHEME = "https"
 SERVER = f"{SCHEME}://{SERVER_IP}:{PORT}"
 INTERVAL = int(os.getenv("AGENT_INTERVAL", "5"))
 RECONNECT_DELAY = int(os.getenv("AGENT_RECONNECT_DELAY", "5"))
+
+ICON_FILE = os.getenv("AGENT_ICON_FILE")
+if ICON_FILE and not Path(ICON_FILE).exists():
+    log.warning("Tray icon not found: %s", ICON_FILE)
+    ICON_FILE = None
+
+
+def _tray_exit(icon, item) -> None:
+    icon.visible = False
+    icon.stop()
+    if WS_LOOP:
+        WS_LOOP.call_soon_threadsafe(WS_LOOP.stop)
+    else:
+        os._exit(0)
+
+
+def start_tray_icon() -> pystray.Icon:
+    """Запустить иконку в системном трее."""
+    image = None
+    try:
+        if ICON_FILE:
+            image = Image.open(ICON_FILE)
+    except Exception as exc:
+        log.error("Failed to load tray icon %s: %s", ICON_FILE, exc)
+    if image is None:
+        image = Image.new("RGB", (64, 64), color="blue")
+    menu = pystray.Menu(
+        pystray.MenuItem(
+            "Показать/скрыть консоль",
+            lambda icon, item: toggle_console(),
+            default=True,
+        ),
+        pystray.MenuItem("Выход", _tray_exit),
+    )
+    icon = pystray.Icon("MonitoringBot", image, "MonitoringBot", menu)
+    threading.Thread(target=icon.run, daemon=True).start()
+    return icon
 
 log.info(
     "Config → server %s verify=%s interval %ss reconnect %ss",
@@ -827,6 +914,10 @@ async def ws_main() -> None:
 # ────────────────────────── main loop ─────────────────────────────────────
 
 def main() -> None:
+    global TRAY_ICON
+    TRAY_ICON = start_tray_icon()
+    if os.name == "nt":
+        threading.Thread(target=_hide_console_on_minimize, daemon=True).start()
     asyncio.run(ws_main())
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ numpy~=2.2.6
 wmi; platform_system=="Windows"
 pywin32>=306; platform_system=="Windows"
 websockets>=11.0
+pystray>=0.19
+pillow>=11.0


### PR DESCRIPTION
## Summary
- remove bundled icon file
- implement tray icon with console toggle on double click
- hide console to tray when minimized
- document console toggle and optional tray icon path

## Testing
- `python -m py_compile client/__main__.py`

------

## Обзор от Sourcery

Добавлен значок в системный трей, позволяющий переключать и скрывать консоль в Windows, с поддержкой настраиваемых значков и обновленной документацией.

Новые возможности:
- Отображение значка в трее при запуске с пунктами меню для отображения/скрытия консоли и выхода из приложения.
- Включено двойное нажатие на значок в трее для выделения и переключения окна консоли в Windows.
- Автоматическое скрытие окна консоли в трей при сворачивании приложения в Windows.

Улучшения:
- Разрешено указание пользовательского изображения значка трея через переменную окружения `AGENT_ICON_FILE` с корректным резервным вариантом и предупреждением.

Сборка:
- Добавлены зависимости pystray и pillow в requirements.

Документация:
- Документирование `AGENT_ICON_FILE` и использования значка в трее в README.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a system tray icon that allows toggling and hiding the console on Windows, with configurable icon support and updated documentation.

New Features:
- Display a tray icon on startup with menu options to show/hide the console and exit the application
- Enable double-click on the tray icon to allocate and toggle the console window on Windows
- Automatically hide the console window to the tray when the application is minimized on Windows

Enhancements:
- Allow specifying a custom tray icon image via the AGENT_ICON_FILE environment variable with graceful fallback and warning

Build:
- Add pystray and pillow dependencies to requirements

Documentation:
- Document AGENT_ICON_FILE and tray icon usage in the README

</details>