### PR TITLE
Run custom plots in worker process

### DIFF
--- a/server/__main__.py
+++ b/server/__main__.py
@@ -791,7 +791,7 @@ async def cmd_plot(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         return await update.message.reply_text("Ключ не найден.")
 
     try:
-        buf = plot_custom(secret, metrics, seconds, top, unit)
+        buf = await run_plot(plot_custom, secret, metrics, seconds, top, unit)
     except ValueError as exc:
         return await update.message.reply_text(f"❌ {exc}")
     if not buf:
@@ -801,8 +801,10 @@ async def cmd_plot(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     if seconds >= 86400:
         doc = InputFile(buf, filename="plot.png")
         await ctx.bot.send_document(chat_id=update.effective_chat.id, document=doc, caption=caption)
+        buf.close()
     else:
         await ctx.bot.send_photo(chat_id=update.effective_chat.id, photo=buf, caption=caption)
+        buf.close()
 
 
 # ─────────────────────- Callback handler ───────────────────────────────────

--- a/server/graphs.py
+++ b/server/graphs.py
@@ -15,6 +15,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 import numpy as np
+import gc
 
 from .db import fetch_metrics, fetch_metrics_full
 
@@ -205,6 +206,7 @@ def plot_metric(secret: str, metric: str, seconds: int):
     plt.tight_layout()
     fig.savefig(buf, dpi=fig.dpi, format="png")
     plt.close(fig)
+    gc.collect()
     buf.seek(0)
     return buf
 
@@ -250,6 +252,7 @@ def plot_net(secret: str, seconds: int):
     plt.tight_layout()
     fig.savefig(buf, dpi=fig.dpi, format="png")
     plt.close(fig)
+    gc.collect()
     buf.seek(0)
     return buf
 
@@ -294,6 +297,7 @@ def plot_all_metrics(secret: str, seconds: int):
     plt.tight_layout()
     fig.savefig(buf, dpi=fig.dpi, format="png")
     plt.close(fig)
+    gc.collect()
     buf.seek(0)
     return buf
 
@@ -428,5 +432,6 @@ def plot_custom(secret: str, metrics: list[str], seconds: int, ylim_top: float |
     plt.tight_layout()
     fig.savefig(buf, dpi=fig.dpi, format="png")
     plt.close(fig)
+    gc.collect()
     buf.seek(0)
     return buf


### PR DESCRIPTION
## Summary
- revert `_make_figure` DPI/width tweaks
- run `/plot` command in a separate process
- close buffers and force garbage collection after plotting

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile server/graphs.py server/__main__.py`
- `python - <<'PY'
from server.graphs import _make_figure
fig, ax = _make_figure(30*86400)
print(fig.get_size_inches(), fig.dpi)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68481d6c46748324b4f19bed419626de

## Обзор от Sourcery

Делегирование построения графиков в отдельный процесс, восстановление размеров фигур по умолчанию и улучшение очистки ресурсов путем закрытия буферов и сбора мусора.

Новые возможности:
- Перенос выполнения команды `/plot` в отдельный рабочий процесс.

Улучшения:
- Закрытие буферов в памяти после отправки изображений графиков.
- Принудительный запуск сборки мусора Python после закрытия фигур matplotlib.
- Отмена пользовательских настроек DPI и ширины при создании фигур.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Delegate plotting to a separate process, restore default figure sizing, and improve resource cleanup by closing buffers and collecting garbage

New Features:
- Offload the `/plot` command execution to a separate worker process

Enhancements:
- Close in-memory buffers after sending plot images
- Force Python garbage collection after closing matplotlib figures
- Revert custom DPI and width adjustments in figure creation

</details>