### PR TITLE
Fix pystray loading on Linux

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ numpy~=2.2.6
 wmi; platform_system=="Windows"
 pywin32>=306; platform_system=="Windows"
 websockets>=11.0
-pystray>=0.19
+pystray>=0.19; platform_system=="Windows"
 pillow>=11.0


### PR DESCRIPTION
## Summary
- avoid importing pystray on non-Windows platforms
- adjust return typing for tray icon
- install pystray only on Windows

## Testing
- `python -m compileall -q client server`

------
