### PR TITLE
Add timestamp to status output

### DIFF
--- a/server/__main__.py
+++ b/server/__main__.py
@@ -371,6 +371,7 @@ from typing import Mapping
 def format_status(row: Mapping[str, Any]) -> str:
     lines = [
         "💻 *PC stats*",
+        f"🕒 Updated: {datetime.fromtimestamp(row['ts']).strftime('%d.%m %H:%M:%S')}",
         f"⏳ Uptime: {timedelta(seconds=int(row['uptime'] or 0))}",
         "*━━━━━━━━━━━CPU━━━━━━━━━━━*",
         f"🖥️ CPU: {row['cpu']:.1f}%",


### PR DESCRIPTION
## Summary
- show last update time in `/status` results

## Testing
- `python -m py_compile server/__main__.py`
- `python -m server --help` *(fails: No module named 'telegram')*

------
https://chatgpt.com/codex/tasks/task_e_68497aa24a1c832492a7539c24f5ed6f