### PR TITLE
Add diagnostics for UDP stability test

### DIFF
--- a/client/__main__.py
+++ b/client/__main__.py
@@ -761,23 +761,43 @@ def _stability_job(interval_ms: int, duration_s: int) -> None:
     global stability_running
     try:
         addr = (SERVER_IP, UDP_PORT)
+        log.info(
+            "stability test to %s:%s interval=%sms duration=%ss",
+            SERVER_IP,
+            UDP_PORT,
+            interval_ms,
+            duration_s,
+        )
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.settimeout(1.0)
         deadline = time.time() + duration_s
         start_ts = time.time()
         rtts: list[float | None] = []
+        pkt_idx = 0
         while time.time() < deadline:
             ts = time.time()
             payload = str(ts).encode()
             try:
                 sock.sendto(payload, addr)
                 sock.recvfrom(1024)
-                rtts.append((time.time() - ts) * 1000)
-            except Exception:
+                rtt = (time.time() - ts) * 1000
+                rtts.append(rtt)
+                log.debug("stability packet %s rtt %.2fms", pkt_idx, rtt)
+            except Exception as exc:
                 rtts.append(None)
+                log.warning("stability packet %s failed: %s", pkt_idx, exc)
+            pkt_idx += 1
             time.sleep(interval_ms / 1000)
         sock.close()
-        ws_send({"stability": {"start_ts": start_ts, "interval_ms": interval_ms, "rtts": rtts}})
+        ws_send(
+            {
+                "stability": {
+                    "start_ts": start_ts,
+                    "interval_ms": interval_ms,
+                    "rtts": rtts,
+                }
+            }
+        )
     except Exception as exc:
         log.error("stability job error: %s", exc)
         ws_send({"stability": {"error": str(exc)}})


### PR DESCRIPTION
## Summary
- add detailed logging around UDP stability probes
- log UDP echo server events and failure conditions

## Testing
- `python -m py_compile client/__main__.py server/__main__.py`


------
https://chatgpt.com/codex/tasks/task_e_68af0b55234c8332bcb788453d60d9f9