### PR TITLE
Add diagnostics for UDP stability test

### DIFF
--- a/server/__main__.py
+++ b/server/__main__.py
@@ -127,23 +127,40 @@ class UDPEchoProtocol(asyncio.DatagramProtocol):
 
     def __init__(self):
         self.transport: asyncio.DatagramTransport | None = None
+        self._count = 0
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         self.transport = transport  # type: ignore[assignment]
+        log.info("UDP echo server ready on %s", UDP_TEST_PORT)
 
     def datagram_received(self, data: bytes, addr) -> None:  # type: ignore[override]
+        self._count += 1
+        if self._count <= 5:
+            log.info("UDP echo recv %d bytes from %s", len(data), addr)
+        else:
+            log.debug("UDP echo recv %d bytes from %s", len(data), addr)
         if self.transport:
-            self.transport.sendto(data, addr)
+            try:
+                self.transport.sendto(data, addr)
+            except Exception as exc:  # pragma: no cover - log for diagnostics
+                log.warning("UDP echo send failed to %s: %s", addr, exc)
 
 
 def start_udp_echo() -> None:
     async def _run() -> None:
-        await asyncio.get_running_loop().create_datagram_endpoint(
-            UDPEchoProtocol, local_addr=("0.0.0.0", UDP_TEST_PORT)
-        )
-        await asyncio.Future()
+        loop = asyncio.get_running_loop()
+        try:
+            await loop.create_datagram_endpoint(
+                UDPEchoProtocol, local_addr=("0.0.0.0", UDP_TEST_PORT)
+            )
+            await asyncio.Future()
+        except Exception:  # pragma: no cover - startup diagnostics
+            log.exception("UDP echo server failed")
 
-    asyncio.run(_run())
+    try:
+        asyncio.run(_run())
+    except Exception:  # pragma: no cover - thread diagnostics
+        log.exception("UDP echo thread crashed")
 
 _load_dotenv()
 _ensure_ssl()


### PR DESCRIPTION
## Summary
- log client UDP socket binding details and use connected socket for stability probes
- report initial UDP echo packets at INFO level for visibility

## Testing
- `python -m py_compile client/__main__.py server/__main__.py`


------
https://chatgpt.com/codex/tasks/task_e_68af0b55234c8332bcb788453d60d9f9

## Сводка от Sourcery

Добавить детальное логирование и обработку ошибок в тест стабильности UDP и эхо-сервер для улучшения диагностики и видимости

Улучшения:
- Логировать параметры теста стабильности клиента и детали привязки UDP-сокета на уровне INFO
- Использовать подключенный UDP-сокет для проверок стабильности и логировать RTT для каждого пакета на уровне DEBUG, а сбои — на уровне WARNING
- Логировать готовность сервера к запуску и первые несколько приемов пакетов на уровне INFO (последующие на уровне DEBUG)
- Обернуть операции отправки сервера, создание конечных точек и цикл выполнения в обработчики исключений для логирования любых ошибок

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add detailed logging and error handling to the UDP stability test and echo server to improve diagnostics and visibility

Enhancements:
- Log client stability test parameters and UDP socket binding details at INFO level
- Use a connected UDP socket for stability probes and log per-packet RTTs at DEBUG and failures at WARNING
- Log server startup readiness and first few packet receptions at INFO (subsequent at DEBUG)
- Wrap server send operations, endpoint creation, and run loop in exception handlers to log any errors

</details>