### PR TITLE
Revert "Add diagnostics for UDP stability test"

### DIFF
--- a/client/__main__.py
+++ b/client/__main__.py
@@ -761,43 +761,23 @@ def _stability_job(interval_ms: int, duration_s: int) -> None:
     global stability_running
     try:
         addr = (SERVER_IP, UDP_PORT)
-        log.info(
-            "stability test to %s:%s interval=%sms duration=%ss",
-            SERVER_IP,
-            UDP_PORT,
-            interval_ms,
-            duration_s,
-        )
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.settimeout(1.0)
         deadline = time.time() + duration_s
         start_ts = time.time()
         rtts: list[float | None] = []
-        pkt_idx = 0
         while time.time() < deadline:
             ts = time.time()
             payload = str(ts).encode()
             try:
                 sock.sendto(payload, addr)
                 sock.recvfrom(1024)
-                rtt = (time.time() - ts) * 1000
-                rtts.append(rtt)
-                log.debug("stability packet %s rtt %.2fms", pkt_idx, rtt)
-            except Exception as exc:
+                rtts.append((time.time() - ts) * 1000)
+            except Exception:
                 rtts.append(None)
-                log.warning("stability packet %s failed: %s", pkt_idx, exc)
-            pkt_idx += 1
             time.sleep(interval_ms / 1000)
         sock.close()
-        ws_send(
-            {
-                "stability": {
-                    "start_ts": start_ts,
-                    "interval_ms": interval_ms,
-                    "rtts": rtts,
-                }
-            }
-        )
+        ws_send({"stability": {"start_ts": start_ts, "interval_ms": interval_ms, "rtts": rtts}})
     except Exception as exc:
         log.error("stability job error: %s", exc)
         ws_send({"stability": {"error": str(exc)}})

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -130,32 +130,20 @@ class UDPEchoProtocol(asyncio.DatagramProtocol):
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         self.transport = transport  # type: ignore[assignment]
-        log.debug("UDP echo server ready on %s", UDP_TEST_PORT)
 
     def datagram_received(self, data: bytes, addr) -> None:  # type: ignore[override]
-        log.debug("UDP echo recv %d bytes from %s", len(data), addr)
         if self.transport:
-            try:
-                self.transport.sendto(data, addr)
-            except Exception as exc:  # pragma: no cover - log for diagnostics
-                log.warning("UDP echo send failed to %s: %s", addr, exc)
+            self.transport.sendto(data, addr)
 
 
 def start_udp_echo() -> None:
     async def _run() -> None:
-        loop = asyncio.get_running_loop()
-        try:
-            await loop.create_datagram_endpoint(
-                UDPEchoProtocol, local_addr=("0.0.0.0", UDP_TEST_PORT)
-            )
-            await asyncio.Future()
-        except Exception:  # pragma: no cover - startup diagnostics
-            log.exception("UDP echo server failed")
+        await asyncio.get_running_loop().create_datagram_endpoint(
+            UDPEchoProtocol, local_addr=("0.0.0.0", UDP_TEST_PORT)
+        )
+        await asyncio.Future()
 
-    try:
-        asyncio.run(_run())
-    except Exception:  # pragma: no cover - thread diagnostics
-        log.exception("UDP echo thread crashed")
+    asyncio.run(_run())
 
 _load_dotenv()
 _ensure_ssl()


### PR DESCRIPTION
Reverts maxundeli/MonitoringBot#67

## Сводка от Sourcery

Откат предыдущего добавления диагностики стабильности UDP и очистка связанного логирования и обработки исключений как в клиентских, так и в серверных модулях

Улучшения:
- Удаление подробной диагностики теста стабильности UDP, такой как операторы логирования и индексация пакетов, из клиента
- Упрощение форматирования полезной нагрузки ws_send клиента для результатов стабильности
- Устранение отладочного логирования и обработки исключений для отправки эхо-датаграмм UDP на сервере
- Оптимизация запуска UDP-эхо сервера путем удаления избыточных блоков try/except и отладочных логов

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert previous addition of UDP stability diagnostics and clean up related logging and exception handling in both client and server modules

Enhancements:
- Remove detailed UDP stability test diagnostics such as log statements and packet indexing from client
- Simplify client ws_send payload formatting for stability results
- Eliminate debug logging and exception handling for UDP echo datagram sends in server
- Streamline server UDP echo startup by removing redundant try/except and debug logs

</details>