### PR TITLE
Add 20 ms UDP stability option and improve packet timing

### DIFF
--- a/server/__main__.py
+++ b/server/__main__.py
@@ -1163,6 +1163,7 @@ async def cb_action(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         kb = InlineKeyboardMarkup(
             [
                 [
+                    InlineKeyboardButton("20 ms", callback_data=f"stab_i:{secret}:20"),
                     InlineKeyboardButton("50 ms", callback_data=f"stab_i:{secret}:50"),
                     InlineKeyboardButton("100 ms", callback_data=f"stab_i:{secret}:100"),
                     InlineKeyboardButton("200 ms", callback_data=f"stab_i:{secret}:200"),


### PR DESCRIPTION
## Summary
- add Telegram button for 20 ms packet interval when running stability tests
- rework client stability job to send UDP echo packets on schedule instead of waiting on RTT

## Testing
- `python -m py_compile client/__main__.py server/__main__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af14416a3c8332a6b2f78f263e8343