### PR TITLE
Handle disconnections during long stability tests

### DIFF
--- a/server/__main__.py
+++ b/server/__main__.py
@@ -1275,7 +1275,7 @@ async def cb_action(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
                 "secret": secret,
                 "chat_id": msg.chat_id,
                 "msg_id": msg.message_id,
-                "deadline": time.time() + duration + 60,
+                "deadline": time.time() + duration + 300,  # allow reconnect
             },
         )
         STAB_JOBS[secret] = job


### PR DESCRIPTION
## Summary
- Queue client messages when WebSocket is down and flush after reconnect
- Extend server stability-test timeout to allow brief network outages

## Testing
- `python -m py_compile client/__main__.py server/__main__.py`


------
