### PR TITLE
feat: add 1 ms option to stability test

### DIFF
--- a/server/__main__.py
+++ b/server/__main__.py
@@ -1174,15 +1174,15 @@ async def cb_action(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         kb = InlineKeyboardMarkup(
             [
                 [
+                    InlineKeyboardButton("1 ms", callback_data=f"stab_i:{secret}:1"),
                     InlineKeyboardButton("20 ms", callback_data=f"stab_i:{secret}:20"),
                     InlineKeyboardButton("50 ms", callback_data=f"stab_i:{secret}:50"),
-                    InlineKeyboardButton("100 ms", callback_data=f"stab_i:{secret}:100"),
-
                 ],
                 [
+                    InlineKeyboardButton("100 ms", callback_data=f"stab_i:{secret}:100"),
                     InlineKeyboardButton("200 ms", callback_data=f"stab_i:{secret}:200"),
                     InlineKeyboardButton("500 ms", callback_data=f"stab_i:{secret}:500"),
-                    InlineKeyboardButton("1000 ms", callback_data=f"stab_i:{secret}:1000"),],
+                ],
                 [InlineKeyboardButton("◀️ Назад", callback_data=f"status:{secret}")],
             ]
         )


### PR DESCRIPTION
## Summary
- add 1 ms packet interval option in stability test
- remove 1000 ms option

## Testing
- `python -m py_compile server/__main__.py client/__main__.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1afe739208332838f4ec981400758

## Сводка от Sourcery

Обновлен пользовательский интерфейс обратного вызова теста стабильности, чтобы включить выбор интервала 1 мс и убрать опцию 1000 мс

Новые возможности:
- Добавлена опция интервала пакетов 1 мс в пользовательский интерфейс теста стабильности

Улучшения:
- Удалена опция интервала пакетов 1000 мс из пользовательского интерфейса теста стабильности

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the stability test callback UI to include a 1 ms interval choice and drop the 1000 ms option

New Features:
- Add 1 ms packet interval option to stability test UI

Enhancements:
- Remove 1000 ms packet interval option from stability test UI

</details>