### PR TITLE
Fix stale process list in status updates

### DIFF
--- a/client/__main__.py
+++ b/client/__main__.py
@@ -356,16 +356,53 @@ def gather_disks_metrics() -> List[dict]:
     return res
 
 
-def gather_top_processes(count: int = 5) -> List[dict]:
+PROC_SAMPLE_DELAY = 0.2
+
+
+def _refresh_proc_cache() -> None:
+    """Обновить кэш времени CPU для процессов без расчёта процентов."""
+
+    now = time.time()
+    alive: set[int] = set()
+    for p in psutil.process_iter(["pid"]):
+        try:
+            cpu_time = sum(p.cpu_times()[:2])
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+        PROC_CACHE[p.pid] = (cpu_time, now)
+        alive.add(p.pid)
+
+    # удалить процессы, которых больше нет
+    for pid in list(PROC_CACHE):
+        if pid not in alive:
+            PROC_CACHE.pop(pid, None)
+
+
+def gather_top_processes(
+    count: int = 5,
+    *,
+    instant: bool = False,
+    sample_delay: float = PROC_SAMPLE_DELAY,
+) -> List[dict]:
     """Вернуть топ процессов по загрузке CPU с учётом RAM.
 
     Процессы с одинаковым именем объединяются (суммируются их CPU и RAM).
+
+    Если ``instant`` установлен, собирается дополнительный моментальный срез
+    CPU с небольшой задержкой, что позволяет показать актуальную картину,
+    не дожидаясь следующего вызова функции.
     """
+
+    if instant:
+        _refresh_proc_cache()
+        if sample_delay > 0:
+            time.sleep(sample_delay)
 
     now = time.time()
     aggregated: dict[str, dict[str, float | int]] = {}
+    alive: set[int] = set()
 
-    for p in psutil.process_iter(["pid", "name"]):
+    for p in psutil.process_iter(["pid", "name", "memory_info"]):
         try:
             name_raw = p.info.get("name") or str(p.pid)
             if name_raw.lower() == "system idle process":
@@ -379,17 +416,25 @@ def gather_top_processes(count: int = 5) -> List[dict]:
                 if dt > 0:
                     cpu = (cpu_time - prev[0]) / dt * 100
             PROC_CACHE[p.pid] = (cpu_time, now)
+            alive.add(p.pid)
 
-            mem = p.memory_info().rss
+            mem_info = p.info.get("memory_info")
+            mem = mem_info.rss if mem_info else p.memory_info().rss
             cpu /= CPU_CORES
 
             key = name_raw.lower()
-            agg = aggregated.setdefault(key, {"name": name_raw, "cpu": 0.0, "ram": 0, "count": 0})
+            agg = aggregated.setdefault(
+                key, {"name": name_raw, "cpu": 0.0, "ram": 0, "count": 0}
+            )
             agg["cpu"] += cpu
             agg["ram"] += mem
             agg["count"] += 1
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             continue
+
+    for pid in list(PROC_CACHE):
+        if pid not in alive:
+            PROC_CACHE.pop(pid, None)
 
     res = []
     for data in aggregated.values():
@@ -865,7 +910,7 @@ def gather_metrics(full: bool = False) -> dict:
     }
     if full:
         data["disks"] = gather_disks_metrics()
-        data["top_procs"] = gather_top_processes()
+        data["top_procs"] = gather_top_processes(instant=True)
     else:
         data["disks"] = []
         data["top_procs"] = []
@@ -1130,7 +1175,7 @@ def do_shutdown():
 async def _send_metrics_loop(ws: websockets.WebSocketClientProtocol) -> None:
     """Периодическая отправка метрик."""
     psutil.cpu_percent(interval=None)
-    gather_top_processes()
+    _refresh_proc_cache()
     init_gpu_metrics()
     while True:
         try:

--- a/client/__main__.py
+++ b/client/__main__.py
@@ -24,6 +24,7 @@ import subprocess
 import socket
 import math
 
+import heapq
 import psutil
 from PIL import Image
 
@@ -399,10 +400,10 @@ def gather_top_processes(
             time.sleep(sample_delay)
 
     now = time.time()
-    aggregated: dict[str, dict[str, float | int]] = {}
+    aggregated: dict[str, dict[str, object]] = {}
     alive: set[int] = set()
 
-    for p in psutil.process_iter(["pid", "name", "memory_info"]):
+    for p in psutil.process_iter(["pid", "name"]):
         try:
             name_raw = p.info.get("name") or str(p.pid)
             if name_raw.lower() == "system idle process":
@@ -417,18 +418,16 @@ def gather_top_processes(
                     cpu = (cpu_time - prev[0]) / dt * 100
             PROC_CACHE[p.pid] = (cpu_time, now)
             alive.add(p.pid)
-
-            mem_info = p.info.get("memory_info")
-            mem = mem_info.rss if mem_info else p.memory_info().rss
             cpu /= CPU_CORES
 
             key = name_raw.lower()
             agg = aggregated.setdefault(
-                key, {"name": name_raw, "cpu": 0.0, "ram": 0, "count": 0}
+                key,
+                {"name": name_raw, "cpu": 0.0, "ram": 0, "count": 0, "pids": []},
             )
             agg["cpu"] += cpu
-            agg["ram"] += mem
             agg["count"] += 1
+            agg["pids"].append(p.pid)
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             continue
 
@@ -436,15 +435,25 @@ def gather_top_processes(
         if pid not in alive:
             PROC_CACHE.pop(pid, None)
 
+    top_entries = heapq.nlargest(count, aggregated.values(), key=lambda x: x["cpu"])
+
+    for entry in top_entries:
+        total_ram = 0
+        for pid in entry["pids"]:
+            try:
+                total_ram += psutil.Process(pid).memory_info().rss
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        entry["ram"] = total_ram
+
     res = []
-    for data in aggregated.values():
+    for data in top_entries:
         name = data["name"]
         if data["count"] > 1:
             name = f"{name} ({data['count']})"
         res.append({"name": name, "cpu": data["cpu"], "ram": data["ram"]})
 
-    res.sort(key=lambda x: x["cpu"], reverse=True)
-    return res[:count]
+    return res
 
 def get_cpu_temp() -> str | None:
     # ── 1) стандартный psutil ─────────────────────────────

--- a/client/__main__.py
+++ b/client/__main__.py
@@ -41,7 +41,7 @@ GPU_VENDOR: str | None = None
 GPU_METRIC_FUNCS: list = []
 NVML_INITED = False
 NVML_HANDLE = None
-CPU_CORES = psutil.cpu_count(logical=False) or psutil.cpu_count() or 1
+CPU_CORES = psutil.cpu_count(logical=True) or psutil.cpu_count() or 1
 import websockets
 WS_LOOP: asyncio.AbstractEventLoop | None = None
 WS_CONN: websockets.WebSocketClientProtocol | None = None


### PR DESCRIPTION
## Summary
- add an instant sampling mode for the top-process collector so /status shows current CPU usage
- refresh the process cache without extra aggregation during the periodic metrics loop

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6beb767d48332a738642c0edba39a

## Сводка от Sourcery

Включение отображения использования ЦП в реальном времени в обновлениях статуса путем добавления режима мгновенной выборки в сборщик топ-процессов, отделения обновления кеша от агрегации и обеспечения обновления и очистки кеша процессов как по запросу, так и в цикле периодического сбора метрик.

Новые возможности:
- Добавлен режим мгновенной выборки в gather_top_processes для использования ЦП в реальном времени
- Представлена функция _refresh_proc_cache для обновления кеша времени ЦП процессов без агрегации

Улучшения:
- Обновление и очистка устаревших записей в кеше процессов во время цикла периодического сбора метрик
- Сбор полных метрик по умолчанию использует мгновенную выборку для данных о топ-процессах

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable real-time CPU usage in status updates by adding an instant sampling mode to the top-process collector, decoupling cache refresh from aggregation, and ensuring the process cache is updated and cleaned both on demand and in the periodic metrics loop.

New Features:
- Add instant sampling mode to gather_top_processes for real-time CPU usage
- Introduce _refresh_proc_cache function to update process CPU time cache without aggregation

Enhancements:
- Refresh and clean stale entries in the process cache during the periodic metrics loop
- Default full metrics collection to use instant sampling for top process data

</details>